### PR TITLE
feat: add support for randomized options in question-answering tasks

### DIFF
--- a/langtest/langtest.py
+++ b/langtest/langtest.py
@@ -678,6 +678,7 @@ class Harness:
             "log_prob_antistereo",
             "diff_threshold",
             "options",
+            "perturbed_options",
             "expected_result",
             "prompt_toxicity",
             "actual_result",
@@ -915,6 +916,7 @@ class Harness:
             "question",
             "ground_truth",
             "options",
+            "perturbed_options",
             "expected_result",
         ]
 

--- a/langtest/transform/robustness.py
+++ b/langtest/transform/robustness.py
@@ -2295,7 +2295,5 @@ class RandomizeOptions(BaseRobustness):
                 shuffle_sample.shuffle(pattern=split_pattern)
 
                 transformed_samples.append(shuffle_sample)
-            elif isinstance(sample, str):
-                transformed_samples.append(None)
 
         return transformed_samples

--- a/langtest/transform/robustness.py
+++ b/langtest/transform/robustness.py
@@ -2295,4 +2295,7 @@ class RandomizeOptions(BaseRobustness):
                 shuffle_sample.shuffle(pattern=split_pattern)
 
                 transformed_samples.append(shuffle_sample)
+            elif isinstance(sample, str):
+                transformed_samples.append(None)
+
         return transformed_samples

--- a/langtest/transform/robustness.py
+++ b/langtest/transform/robustness.py
@@ -2281,7 +2281,7 @@ class RandomizeOptions(BaseRobustness):
         """
         transformed_samples = []
         for sample in sample_list:
-            if sample.task == "question-answering" and isinstance(sample, QASample):
+            if isinstance(sample, QASample) and sample.task == "question-answering":
                 shuffle_sample = ShuffleOptions(
                     **sample.model_dump(
                         exclude_none=True,

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -437,6 +437,27 @@ class RobustnessTestCase(unittest.TestCase):
         for sample in transformed_samples:
             self.assertNotEqual(sample.test_case, sample.original)
 
+    def test_randomize_options(self) -> None:
+        """
+        Test the RandomizeOptions transformation.
+        """
+        transformed_samples = RandomizeOptions.transform(
+            sample_list=[
+                QASample(
+                    original_question="What is John Snow Labs?",
+                    original_context="John Snow Labs is a healthcare company specializing in accelerating progress in data science.",
+                    options="A. healthcare company\nB. tech company\nC. data science company",
+                    task="question-answering",
+                )
+            ]
+        )
+        self.assertIsInstance(transformed_samples, list)
+        for sample in transformed_samples:
+            self.assertIsInstance(sample, ShuffleOptions)
+            if isinstance(sample, ShuffleOptions):
+                sample.shuffle()
+                self.assertTrue(sample.options != sample.perturbed_options)
+
 
 class RobustnessTestCaseQaAndSummarization(unittest.TestCase):
     """
@@ -508,6 +529,7 @@ class RobustnessTestCaseQaAndSummarization(unittest.TestCase):
                     "british_to_american",
                     "add_context",
                     "multiple_perturbations",
+                    "randomize_options",
                 ]:
                     sample.transform(test_func, {}, prob)
                 elif test in ["american_to_british", "british_to_american"]:


### PR DESCRIPTION
```python
mcq_prompt = """
Step 1: Read the question very carefully.
Step 2: Review all four options labeled A, B, C, and D.
Step 3: Identify the single best correct answer.
Step 4: Reply only with the letter A, B, C, or D (no extra text).

Example:
Question:
Which planet is known as the Red Planet?
Options:
A. Earth
B. Venus
C. Mars
D. Jupiter
Answer:
C

Now answer the following:
Question:
{question}
Options:
{options}
Answer:

"""
```

Harness Setup
```python
harness = Harness(
    task="question-answering",
    model={
        "model": "llama3.2",
        "hub": "ollama",
        "type": "chat"
    },
    data={
        "data_source":"MedQA",
        "split": "test-tiny",
    },
    config={
        "model_parameters": {
            "user_prompt": mcq_prompt,
        },
        
        "tests": {
            "defaults": {
                "min_pass_rate": 0.5,
            },
            "robustness": {
                "randomize_options": {
                    "min_pass_rate": 0.8,
                }
            }
        },
    }
)
```

```python
harness.generate().run().report()
```

<img width="693" height="72" alt="image" src="https://github.com/user-attachments/assets/7995f966-bca4-4046-a028-84c86ae3350b" />
