### PR TITLE
 Replace pkg_resources with importlib.resources for Modern Resource File Handling

### DIFF
--- a/langtest/datahandler/datasource.py
+++ b/langtest/datahandler/datasource.py
@@ -1215,19 +1215,19 @@ class JSONLDataset(BaseDataset):
         elif dataset_name in additional_datasets.keys():
             files = additional_datasets[dataset_name]
             for file in files:
-                file_loc = resources.files("langtest").joinpath(
-                    f"/data/{dataset_name}/{file}"
-                )
+                file_loc = str(resources.files("langtest").joinpath(
+                    f"data/{dataset_name}/{file}"
+                ))
                 data = self.__load_jsonl(file_loc, dataset_name, data, *args, **kwargs)
         else:
             if dataset_name == "MedMCQA":
-                data_files = resources.files("langtest").joinpath(
-                    f"/data/{dataset_name}/MedMCQA-Validation/"
-                )
+                data_files = str(resources.files("langtest").joinpath(
+                    f"data/{dataset_name}/MedMCQA-Validation/"
+                ))
             else:
-                data_files = resources.files("langtest").joinpath(
-                    f"/data/{dataset_name}/"
-                )
+                data_files = str(resources.files("langtest").joinpath(
+                    f"data/{dataset_name}/"
+                ))
 
             all_files = glob.glob(f"{data_files}/**/*.jsonl", recursive=True)
             jsonl_files = [file for file in all_files if re.match(r".*\.jsonl$", file)]

--- a/langtest/datahandler/datasource.py
+++ b/langtest/datahandler/datasource.py
@@ -25,7 +25,9 @@ from langtest.utils.custom_types import (
 from ..utils.lib_manager import try_import_lib
 from ..errors import Warnings, Errors
 import glob
-from pkg_resources import resource_filename
+
+# from pkg_resources import resource_filename
+from importlib import resources
 from langtest.logger import logger
 
 COLUMN_MAPPER = {
@@ -1213,15 +1215,19 @@ class JSONLDataset(BaseDataset):
         elif dataset_name in additional_datasets.keys():
             files = additional_datasets[dataset_name]
             for file in files:
-                file_loc = resource_filename("langtest", f"/data/{dataset_name}/{file}")
+                file_loc = resources.files("langtest").joinpath(
+                    f"/data/{dataset_name}/{file}"
+                )
                 data = self.__load_jsonl(file_loc, dataset_name, data, *args, **kwargs)
         else:
             if dataset_name == "MedMCQA":
-                data_files = resource_filename(
-                    "langtest", f"/data/{dataset_name}/MedMCQA-Validation/"
+                data_files = resources.files("langtest").joinpath(
+                    f"/data/{dataset_name}/MedMCQA-Validation/"
                 )
             else:
-                data_files = resource_filename("langtest", f"/data/{dataset_name}/")
+                data_files = resources.files("langtest").joinpath(
+                    f"/data/{dataset_name}/"
+                )
 
             all_files = glob.glob(f"{data_files}/**/*.jsonl", recursive=True)
             jsonl_files = [file for file in all_files if re.match(r".*\.jsonl$", file)]

--- a/langtest/datahandler/datasource.py
+++ b/langtest/datahandler/datasource.py
@@ -1215,19 +1215,21 @@ class JSONLDataset(BaseDataset):
         elif dataset_name in additional_datasets.keys():
             files = additional_datasets[dataset_name]
             for file in files:
-                file_loc = str(resources.files("langtest").joinpath(
-                    f"data/{dataset_name}/{file}"
-                ))
+                file_loc = str(
+                    resources.files("langtest").joinpath(f"data/{dataset_name}/{file}")
+                )
                 data = self.__load_jsonl(file_loc, dataset_name, data, *args, **kwargs)
         else:
             if dataset_name == "MedMCQA":
-                data_files = str(resources.files("langtest").joinpath(
-                    f"data/{dataset_name}/MedMCQA-Validation/"
-                ))
+                data_files = str(
+                    resources.files("langtest").joinpath(
+                        f"data/{dataset_name}/MedMCQA-Validation/"
+                    )
+                )
             else:
-                data_files = str(resources.files("langtest").joinpath(
-                    f"data/{dataset_name}/"
-                ))
+                data_files = str(
+                    resources.files("langtest").joinpath(f"data/{dataset_name}/")
+                )
 
             all_files = glob.glob(f"{data_files}/**/*.jsonl", recursive=True)
             jsonl_files = [file for file in all_files if re.match(r".*\.jsonl$", file)]

--- a/langtest/langtest.py
+++ b/langtest/langtest.py
@@ -209,7 +209,7 @@ class Harness:
         else:
             logging.info(Warnings.W001())
             self._config = self.configure(
-                str(resources.files("langtest.data").joinpath("config.yml"))
+                str(resources.files("langtest").joinpath("data/config.yml"))
             )
 
         # prompt config

--- a/langtest/langtest.py
+++ b/langtest/langtest.py
@@ -11,7 +11,8 @@ import pandas as pd
 import yaml
 import random
 
-from pkg_resources import resource_filename
+# from pkg_resources import resource_filename
+from importlib import resources
 
 from langtest.types import DatasetConfig, HarnessConfig, ModelConfig
 
@@ -208,7 +209,7 @@ class Harness:
         else:
             logging.info(Warnings.W001())
             self._config = self.configure(
-                resource_filename("langtest", "data/config.yml")
+                str(resources.files("langtest.data").joinpath("config.yml"))
             )
 
         # prompt config
@@ -1494,10 +1495,10 @@ class Harness:
             data_path = os.path.join(
                 "data", self.DEFAULTS_DATASET[(self.task, model, hub)]
             )
-            data = {"data_source": resource_filename("langtest", data_path)}
+            data = {"data_source": str(resources.files("langtest").joinpath(data_path))}
             o_data = DataFactory(data, task=self.task).load()
             if model == "textcat_imdb":
-                model = resource_filename("langtest", "data/textcat_imdb")
+                model = str(resources.files("langtest").joinpath("data/textcat_imdb"))
             self.is_default = True
             logging.info(Warnings.W002(info=(self.task, model, hub)))
         elif data is None and self.task.category == "ideology":

--- a/langtest/pipelines/embedding.py
+++ b/langtest/pipelines/embedding.py
@@ -3,7 +3,9 @@ import pickle
 import click
 import asyncio
 from langtest import cli
-from pkg_resources import resource_filename
+
+# from pkg_resources import resource_filename
+from importlib import resources
 from langtest.config import read_config
 
 try:
@@ -18,7 +20,9 @@ try:
 except ImportError as e:
     print(e, "please install llama_index using `pip install llama-index`")
 
-default_qa_pkl = resource_filename("langtest", "data/Retrieval_Datasets/qa_dataset.pkl")
+default_qa_pkl = resources.files("langtest").joinpath(
+    "data/Retrieval_Datasets/qa_dataset.pkl"
+)
 
 # set environment variables
 os.environ["OPENAI_API_KEY"] = read_config("openai_api_key")

--- a/langtest/pipelines/embedding.py
+++ b/langtest/pipelines/embedding.py
@@ -20,9 +20,9 @@ try:
 except ImportError as e:
     print(e, "please install llama_index using `pip install llama-index`")
 
-default_qa_pkl = str(resources.files("langtest").joinpath(
-    "data/Retrieval_Datasets/qa_dataset.pkl"
-))
+default_qa_pkl = str(
+    resources.files("langtest").joinpath("data/Retrieval_Datasets/qa_dataset.pkl")
+)
 
 # set environment variables
 os.environ["OPENAI_API_KEY"] = read_config("openai_api_key")

--- a/langtest/pipelines/embedding.py
+++ b/langtest/pipelines/embedding.py
@@ -20,9 +20,9 @@ try:
 except ImportError as e:
     print(e, "please install llama_index using `pip install llama-index`")
 
-default_qa_pkl = resources.files("langtest").joinpath(
+default_qa_pkl = str(resources.files("langtest").joinpath(
     "data/Retrieval_Datasets/qa_dataset.pkl"
-)
+))
 
 # set environment variables
 os.environ["OPENAI_API_KEY"] = read_config("openai_api_key")

--- a/langtest/transform/clinical.py
+++ b/langtest/transform/clinical.py
@@ -416,9 +416,6 @@ class Brand2Generic(BaseClinical):
         progress_bar = kwargs.get("progress_bar", False)
 
         for sample in sample_list:
-            # if hasattr(sample, "run"):
-            #     sample.run(model, **kwargs)
-            # else:
             if isinstance(sample, QASample):
                 # build the template
                 temp_temlate = "Context:\n {context}\nQuestion:\n {text}"

--- a/langtest/utils/config_utils.py
+++ b/langtest/utils/config_utils.py
@@ -1,51 +1,87 @@
 from typing import Any, Dict, List
-from pkg_resources import resource_filename
+
+# from pkg_resources import resource_filename
+from importlib import resources
 
 
 LLM_DEFAULTS_CONFIG = {
-    "azure-openai": resource_filename(
-        "langtest", "data/config/QA_summarization_azure_config.yml"
+    "azure-openai": str(
+        resources.files("langtest").joinpath(
+            "data/config/QA_summarization_azure_config.yml"
+        )
     ),
-    "huggingface": resource_filename(
-        "langtest", "data/config/QA_summarization_huggingface_config.yml"
+    "huggingface": str(
+        resources.files("langtest").joinpath(
+            "data/config/QA_summarization_huggingface_config.yml"
+        )
     ),
-    "default": resource_filename("langtest", "data/config/QA_summarization_config.yml"),
+    "default": str(
+        resources.files("langtest").joinpath("data/config/QA_summarization_config.yml")
+    ),
 }
 
 DEFAULTS_CONFIG: Dict[str, Any] = {
     "question-answering": LLM_DEFAULTS_CONFIG,
     "summarization": LLM_DEFAULTS_CONFIG,
-    "ideology": resource_filename("langtest", "data/config/political_config.yml"),
-    "toxicity": resource_filename("langtest", "data/config/toxicity_config.yml"),
-    "clinical": resource_filename("langtest", "data/config/clinical_config.yml"),
-    "legal": resource_filename("langtest", "data/config/legal_config.yml"),
-    "crows-pairs": resource_filename("langtest", "data/config/crows_pairs_config.yml"),
-    "stereoset": resource_filename("langtest", "data/config/stereoset_config.yml"),
-    "security": resource_filename("langtest", "data/config/security_config.yml"),
-    "disinformation": resource_filename(
-        "langtest", "data/config/disinformation_config.yml"
+    "ideology": str(
+        resources.files("langtest").joinpath("data/config/political_config.yml")
     ),
-    "factuality": resource_filename("langtest", "data/config/factuality_config.yml"),
-    "sycophancy": resource_filename("langtest", "data/config/sycophancy_config.yml"),
+    "toxicity": str(
+        resources.files("langtest").joinpath("data/config/toxicity_config.yml")
+    ),
+    "clinical": str(
+        resources.files("langtest").joinpath("data/config/clinical_config.yml")
+    ),
+    "legal": str(resources.files("langtest").joinpath("data/config/legal_config.yml")),
+    "crows-pairs": str(
+        resources.files("langtest").joinpath("data/config/crows_pairs_config.yml")
+    ),
+    "stereoset": str(
+        resources.files("langtest").joinpath("data/config/stereoset_config.yml")
+    ),
+    "security": str(
+        resources.files("langtest").joinpath("data/config/security_config.yml")
+    ),
+    "disinformation": str(
+        resources.files("langtest").joinpath("data/config/disinformation_config.yml")
+    ),
+    "factuality": str(
+        resources.files("langtest").joinpath("data/config/factuality_config.yml")
+    ),
+    "sycophancy": str(
+        resources.files("langtest").joinpath("data/config/sycophancy_config.yml")
+    ),
     "sensitivity": {
-        "huggingface": resource_filename(
-            "langtest", "data/config/sensitivity_huggingface_config.yml"
+        "huggingface": str(
+            resources.files("langtest").joinpath(
+                "data/config/sensitivity_huggingface_config.yml"
+            )
         ),
-        "default": resource_filename("langtest", "data/config/sensitivity_config.yml"),
+        "default": str(
+            resources.files("langtest").joinpath("data/config/sensitivity_config.yml")
+        ),
     },
     "translation": {
-        "default": resource_filename(
-            "langtest", "data/config/translation_transformers_config.yml"
+        "default": str(
+            resources.files("langtest").joinpath(
+                "data/config/translation_transformers_config.yml"
+            )
         ),
-        "johnsnowlabs": resource_filename(
-            "langtest", "data/config/translation_johnsnowlabs_config.yml"
+        "johnsnowlabs": str(
+            resources.files("langtest").joinpath(
+                "data/config/translation_johnsnowlabs_config.yml"
+            )
         ),
     },
     "wino-bias": {
-        "huggingface": resource_filename(
-            "langtest", "data/config/wino_huggingface_config.yml"
+        "huggingface": str(
+            resources.files("langtest").joinpath(
+                "data/config/wino_huggingface_config.yml"
+            )
         ),
-        "default": resource_filename("langtest", "data/config/wino_llm_config.yml"),
+        "default": str(
+            resources.files("langtest").joinpath("data/config/wino_llm_config.yml")
+        ),
     },
 }
 


### PR DESCRIPTION
This pull request updates how resource files are accessed in `langtest/langtest.py` by replacing the deprecated `pkg_resources` API with the modern `importlib.resources` module. This improves compatibility and reliability when loading configuration and data files.

Resource loading modernization:

* Replaced all usages of `resource_filename` from `pkg_resources` with the recommended `importlib.resources.files` API for accessing files within the `langtest` package.
* Updated the configuration file loading in the `__init__` method to use `importlib.resources`, ensuring the path to `config.yml` is resolved correctly.
* Modified dataset loading logic in `__single_dataset_loading` to use `importlib.resources` for both the default dataset and the `textcat_imdb` model resource path.