### PR TITLE
chore: update poetry version to 2.1.3 in build workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: snok/install-poetry@v1
         with:
-          version: 1.3.1
+          version: 2.1.3
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true


### PR DESCRIPTION
This pull request updates the version of Poetry used in the GitHub Actions workflow. The workflow now uses Poetry version 2.1.3 instead of 1.3.1 to manage Python dependencies and virtual environments.