### PR TITLE
fix: update Poetry version to 2.1.3 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/llm_tests_build.yml
+++ b/.github/workflows/llm_tests_build.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: snok/install-poetry@v1
         with:
-          version: 1.3.1
+          version: 2.1.3
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true


### PR DESCRIPTION
This pull request updates the Poetry dependency manager version used in the GitHub Actions workflow. The workflow will now use Poetry version 2.1.3 instead of 1.3.1 to manage Python dependencies and virtual environments.

- Updated the `llm_tests_build.yml` workflow to use Poetry version 2.1.3, ensuring compatibility with newer features and bug fixes.